### PR TITLE
Remove the context '/breathing-space' from our routes file as this is…

### DIFF
--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,5 +1,5 @@
 # Add all the application routes to the app.routes file
-->         /breathing-space           app.Routes
+->         /                          app.Routes
 ->         /                          health.Routes
 ->         /                          apiPlatform.Routes
 

--- a/it/uk/gov/hmrc/breathingspaceifproxy/controller/BreathingSpaceControllerISpec.scala
+++ b/it/uk/gov/hmrc/breathingspaceifproxy/controller/BreathingSpaceControllerISpec.scala
@@ -28,9 +28,9 @@ import uk.gov.hmrc.breathingspaceifproxy.support.{BaseISpec, HttpMethod}
 
 class BreathingSpaceControllerISpec extends BaseISpec with BreathingSpaceConnectorHelper {
 
-  val identityDetailsPath = s"/$localContext/debtor/${nino.value}/details"
+  val identityDetailsPath = s"/debtor/${nino.value}/details"
 
-  s"GET /$localContext/debtor/:nino/details" should {
+  s"GET /debtor/:nino/details" should {
 
     "return 200(OK) and debtor details when the Nino is valid" in {
       val expectedBody = debtorDetails(nino)
@@ -88,13 +88,13 @@ class BreathingSpaceControllerISpec extends BaseISpec with BreathingSpaceConnect
       val connectorUrl = retrieveIdentityDetailsPath(appConfig, unknownNino)
       stubCall(HttpMethod.Get, connectorUrl, Status.NOT_FOUND, s"Nino(${unknownNino.value}) is unknown")
 
-      val path = s"/$localContext/debtor/${unknownNino.value}/details"
+      val path = s"/debtor/${unknownNino.value}/details"
       val result = route(fakeApplication, fakeRequest(Helpers.GET, path)).get
       status(result) shouldBe Status.NOT_FOUND
     }
 
     "return 422(UnprocessableEntity) when the Nino is invalid" in {
-      val request = fakeRequest(Helpers.GET, s"/$localContext/debtor/12345/details")
+      val request = fakeRequest(Helpers.GET, s"/debtor/12345/details")
       val result = route(fakeApplication, request).get
       status(result) shouldBe Status.UNPROCESSABLE_ENTITY
     }

--- a/it/uk/gov/hmrc/breathingspaceifproxy/support/BaseISpec.scala
+++ b/it/uk/gov/hmrc/breathingspaceifproxy/support/BaseISpec.scala
@@ -58,8 +58,6 @@ abstract class BaseISpec
 
   lazy val appConfig: AppConfig = fakeApplication.injector.instanceOf[AppConfig]
 
-  lazy val localContext: String = "breathing-space"
-
   def fakeRequest(method: String, path: String): FakeRequest[AnyContentAsEmpty.type] =
     FakeRequest(method, path).withHeaders(
       HeaderNames.CONTENT_TYPE -> MimeTypes.JSON,


### PR DESCRIPTION
… provided by the API Platform (external to our micro-service)