### PR TITLE
[BS-301][LB] Fix the date-range validation

### DIFF
--- a/app/uk/gov/hmrc/breathingspaceifproxy/controller/PeriodsController.scala
+++ b/app/uk/gov/hmrc/breathingspaceifproxy/controller/PeriodsController.scala
@@ -83,8 +83,9 @@ class PeriodsController @Inject()(appConfig: AppConfig, cc: ControllerComponents
       (
         validateDate(period.startDate),
         validateDate(endDate),
+        validateDateRange(period.startDate, endDate),
         validateDateTime(period.pegaRequestTimestamp)
-      ).mapN((startDate, endDate, _) => validateDateRange(startDate, endDate))
+      ).mapN((_, _, _, _) => unit)
     }
 
   private val BreathingSpaceProgramStartingYear = 2020
@@ -101,6 +102,7 @@ class PeriodsController @Inject()(appConfig: AppConfig, cc: ControllerComponents
     } else unit.validNec
 
   private def validateDateRange(startDate: LocalDate, endDate: LocalDate): Validation[Unit] =
-    if (startDate.isBefore(endDate)) unit.validNec
-    else Error(INVALID_DATE_RANGE, s". startDate($startDate) is after endDate($endDate)".some).invalidNec
+    if (endDate.isBefore(startDate)) {
+      Error(INVALID_DATE_RANGE, s". startDate($startDate) is after endDate($endDate)".some).invalidNec
+    } else unit.validNec
 }

--- a/app/uk/gov/hmrc/breathingspaceifproxy/model/Error.scala
+++ b/app/uk/gov/hmrc/breathingspaceifproxy/model/Error.scala
@@ -28,7 +28,7 @@ object BaseError extends Enum[BaseError] {
   case object INTERNAL_SERVER_ERROR extends BaseError("Internal server error")
   case object INVALID_HEADER extends BaseError(s"Invalid value for the header")
   case object INVALID_DATE extends BaseError("Invalid date")
-  case object INVALID_DATE_RANGE extends BaseError("End-date after start-date")
+  case object INVALID_DATE_RANGE extends BaseError("End-date before start-date")
   case object INVALID_JSON extends BaseError("Payload not in the expected Json format")
   case object INVALID_NINO extends BaseError("Invalid Nino")
   case object RESOURCE_NOT_FOUND extends BaseError("Resource not found")

--- a/test/uk/gov/hmrc/breathingspaceifproxy/support/TestData.scala
+++ b/test/uk/gov/hmrc/breathingspaceifproxy/support/TestData.scala
@@ -32,13 +32,19 @@ trait TestData {
   val correlationId = CorrelationId(UUID.randomUUID().toString)
   val unattendedStaffId = StaffId("0000000")
 
-  lazy val period = Period(
+  lazy val validDateRangePeriod = Period(
     LocalDate.now.minusMonths(3),
     LocalDate.now.minusMonths(1).some,
     ZonedDateTime.now
   )
 
-  lazy val periods: List[Period] = List(period, period)
+  lazy val invalidDateRangePeriod = Period(
+    LocalDate.now.minusMonths(3),
+    LocalDate.now.minusMonths(4).some,
+    ZonedDateTime.now
+  )
+
+  lazy val periods: List[Period] = List(validDateRangePeriod, validDateRangePeriod)
 
   def createPeriodsRequest(nino: String, periods: Periods): JsValue =
     Json.toJson(CreatePeriodsRequest(nino, periods))


### PR DESCRIPTION
Fix the date-range validation in the payload of the Request for "Set BS periods": endDate cannot be before startDate