### PR TITLE
[Tech-Debt][LB] Small fix to the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This &#xb5;service enables interaction between PEGA Cloud, the platform controll
 
 Start a terminal and enter:
 ```
-$ sm --start AUTH
+$ sm --start AUTH AUTH_LOGIN_API AUTH_LOGIN_STUB USER_DETAILS IDENTITY_VERIFICATION ASSETS_FRONTEND -f
 $ sbt run
 ```
 


### PR DESCRIPTION
I have not created a SM profile yet because atm we cannot really authorise requests locally due to the fact that the AUTH stub does not accept enrolments, which instead we need, for privileged applications .

This amendment to the README is mainly to consider as a memo to note down what auth services we would need to start the app locally.