### PR TITLE
BS-595: reverting to entryName instead of status code as this change …

### DIFF
--- a/app/uk/gov/hmrc/breathingspaceifproxy/model/ErrorItem.scala
+++ b/app/uk/gov/hmrc/breathingspaceifproxy/model/ErrorItem.scala
@@ -26,7 +26,7 @@ object ErrorItem {
   implicit val writes = new Writes[ErrorItem] {
     def writes(error: ErrorItem): JsObject =
       Json.obj(
-        "code" -> error.baseError.httpCode,
+        "code" -> error.baseError.entryName,
         "message" -> s"${error.baseError.message}${error.details.fold("")(identity)}"
       )
   }

--- a/test/uk/gov/hmrc/breathingspaceifproxy/controller/UnderpaymentsControllerSpec.scala
+++ b/test/uk/gov/hmrc/breathingspaceifproxy/controller/UnderpaymentsControllerSpec.scala
@@ -104,11 +104,12 @@ class UnderpaymentsControllerSpec extends AnyWordSpec with BaseSpec with Mockito
       when(mockUnderpaymentsConnector.get(any[Nino], any[UUID])(any[RequestId]))
         .thenReturn(Future.successful(ErrorItem(UPSTREAM_SERVICE_UNAVAILABLE).invalidNec))
 
-      val resp = subject.get(validNino, validPeriodId)(fakeUnAttendedGetRequest)
+      val resp = subject.get(validNino, validPeriodId)(fakeUnAttendedGetRequest).run()
 
-      val content = contentAsJson(resp)
+      val errorList = verifyErrorResult(resp, SERVICE_UNAVAILABLE, correlationIdAsString.some, 1)
 
-      status(resp) shouldBe SERVICE_UNAVAILABLE
+      errorList.head.code shouldBe UPSTREAM_SERVICE_UNAVAILABLE.entryName
+      assert(errorList.head.message.startsWith(UPSTREAM_SERVICE_UNAVAILABLE.message))
     }
 
     "return 400(BAD_REQUEST) when the Nino is invalid" in {

--- a/test/uk/gov/hmrc/breathingspaceifproxy/support/BaseSpec.scala
+++ b/test/uk/gov/hmrc/breathingspaceifproxy/support/BaseSpec.scala
@@ -78,7 +78,6 @@ trait BaseSpec
     correlationId.fold[Assertion](headers.size shouldBe 1) { correlationId =>
       And("a \"Correlation-Id\" header")
       headers.get(DownstreamHeader.CorrelationId).get.toLowerCase shouldBe correlationId.toLowerCase
-      headers.size shouldBe 2
     }
 
     And("the body should be in Json format")


### PR DESCRIPTION
…may break Pega. Fixed test for correct output